### PR TITLE
fix ObjectMerge

### DIFF
--- a/functionsahkshouldfuckinghave.ahk
+++ b/functionsahkshouldfuckinghave.ahk
@@ -61,7 +61,7 @@ Clone(obj) {
 ObjectMerge(array1, array2c) {
 	array2 := clone(array2c)
 	for key, value in array1 {
-		array2[key] := (IsObject(value) && !value.base.IsArray) ? ObjectMerge(value, array2[key]) : value
+		array2[key] := (IsObject(value) && !value.base.IsArray) ? ObjectMerge(array2[key], value) : value
 	}
 
 	return array2


### PR DESCRIPTION
`ObjectMerge({login: 1, prms: {test: 1}}, {login: 0}) ; -> {login: 1, prms: ''}`
but should be
`ObjectMerge({login: 1, prms: {test: 1}}, {login: 0}) ; -> {login: 1, prms: {test: 1}}`